### PR TITLE
MARP-2593 Code Scanning for all market repositories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,30 +7,11 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
-jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - name: Checkout Deepl-mock repo
-        uses: actions/checkout@v4
-        with:
-          repository: DeepLcom/deepl-mock
-          path: deepl-mock
-          ref: main
-      - name: Log in to docker hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.MARKET_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.MARKET_DOCKERHUB_TOKEN }}
-      - name: Build latest Deepl-mock test image and publish it in Octopus's public docker hub
-        run: |
-          IMAGE_NAME=octopusaxonivy/mock-deepl-server:latest
-          docker build -t $IMAGE_NAME deepl-mock
-          docker push $IMAGE_NAME
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 
+jobs:
   build:
-    needs: prepare
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@feature/MARP-2593-Code-Scanning-for-all-market-repositories
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,4 @@ jobs:
 
   build:
     needs: prepare
-    permissions:
-      contents: read
-      actions: write
-      checks: write
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@feature/MARP-2593-Code-Scanning-for-all-market-repositories

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,6 +6,11 @@ on:
     - cron:  '21 21 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v6

--- a/.github/workflows/publish-release-drafter.yml
+++ b/.github/workflows/publish-release-drafter.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish_release_drafter:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release_drafter:
     uses: axonivy-market/github-workflows/.github/workflows/release-drafter.yml@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Release-Build
 
 on: workflow_dispatch
 
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
 jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/release.yml@v6


### PR DESCRIPTION
Hi @ivy-rew, I'm working on story https://1ivy.atlassian.net/browse/MARP-2593, which involves resolving code scanning alerts for each repository.

As far as I know, code scanning only analyzes workflows that run directly within the repository, not  the called reusable workflows. Therefore, I added the permissions section directly to the workflows for all default branches in the repo to ensure they are properly scanned.

So could you check this PR? Thank you :bowtie: