### PR TITLE
MARP-3642 Add cspell configuration and update CI workflow (release/12.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,5 @@ jobs:
   build:
     needs: prepare
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
+    with:
+      cspellConfig: cspell.json

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2",
+  "files": [
+    "**/*.md",
+    "**/*_en.yaml",
+    "**/variables.yaml",
+    "**/*.xhtml"
+  ],
+  "ignorePaths": [
+    "**/*_de.md",
+    "**/*_DE.md",
+    "**/webContent/layouts/frame*.xhtml",
+    "**/webContent/layouts/basic*.xhtml",
+    "**/webContent/layouts/includes/*.xhtml"
+  ],
+  "words": [
+    "AxonIvy", "axonactive", "ivy", "ivyteam", "wawa", "Up2date",
+    "e2e", "panelgrid", "toggleable", "orderlist", "tablewrapper",
+    "hoverable", "gridlines", "formgrid", "maxdate", "mindate",
+    "chkbox", "confirmdialog", "maximizable", "outputlabel",
+    "webcontent", "Unsorting", "nogutter", "navicon", "HANA",
+    "Recordset", "Recordsets", "fileref", "newkey", "keyout", "inkey",
+    "primeflex", "primefaces", "dynaForm", "dyna",
+    "Startable", "caseprocessviewer", "EMLX", "webservice", "apikey",
+    "Successfactors", "statefuldatatable", "datatable", "Keypair",
+    "azureopenai", "rebex", "sshkey", "Keyphrase", "sshpassphrase",
+    "chartjs", "datalabels", "masterdetail", "Weblate", "XOAUTH", "sasl",
+    "imap", "imaps", "clazz", "daemonless", "npipe", "glassfish", "HSQL",
+    "hsqldb", "chatbots", "SOQL"
+  ]
+}


### PR DESCRIPTION
MARP-3642 This PR adds cspell.json to the repository root and updates CI-Build to use the internal github-workflows with cspell support.